### PR TITLE
Move to labs.mapbox.com

### DIFF
--- a/html.js
+++ b/html.js
@@ -7,6 +7,7 @@ module.exports = `
     <meta charSet="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>SVG to GeoJSON</title>
+    <link rel="canonical" href="https://labs.mapbox.com/svg-to-geojson/">
     <link rel="stylesheet" href="https://api.mapbox.com/mapbox-assembly/mbx/v0.20.2/assembly.min.css">
     <script src="https://api.mapbox.com/mapbox-assembly/mbx/v0.20.2/assembly.js"></script>
   </head>


### PR DESCRIPTION
As discussed in https://github.com/mapbox/frontend-platform-team/issues/44, we are planning to move this repository the `labs` subdomain.
 
This PR adds:
- A canonical link to help search engines discern between duplicates and the original `labs.mapbox.com/svg-to-geojson`.
